### PR TITLE
Fixes Window's require issue.

### DIFF
--- a/lib/melomel/cucumber.rb
+++ b/lib/melomel/cucumber.rb
@@ -1,6 +1,6 @@
 require 'cucumber'
 require 'melomel'
-Dir.glob(File.dirname(__FILE__) + '/cucumber/*', &method(:require))
+Dir.glob(File.dirname(__FILE__) + '/cucumber/*') {|file| require file }
 
 # This class holds utility methods for running Cucumber steps.
 module Melomel


### PR DESCRIPTION
I had an issue in windows when the code was written as it was would produce the following error
super: no superclass method `require' for #Object:0x43a91d8 (NoMethodError)

Replacing the &method(:require) with a formatted block fixed the issue.
